### PR TITLE
Improve type documentation

### DIFF
--- a/doc/any.md
+++ b/doc/any.md
@@ -1,5 +1,5 @@
 @property {can-type.typeobject} can-type.any Any
-@parent can-type
+@parent can-type/types
 @description The `Any` type represents any type.
 
 @signature `type.Any`

--- a/doc/can-type.md
+++ b/doc/can-type.md
@@ -1,11 +1,13 @@
 @page can-type
 @parent can-data-validation
 @collection can-ecosystem
-@description Define type objects that can coerce and check types.
+@group can-type/methods 0 methods
+@group can-type/types 1 types
+@outline 2
 
 @body
 
-## Usage
+## Overview
 
 Use can-type to define type checking rules around types. Works well with [can-define], [can-define-object], and [can-stache-define-element].
 
@@ -76,3 +78,83 @@ const dateType = type.maybeConvert(Date);
 Reflect.convert("12/04/1433", dateType);
 // -> Date(1433, 12, 04)
 ```
+
+## Creating Models and ViewModels
+
+can-type is useful for creating typed properties in [can-define-object]. Some DefineObjects you might want to have stricter type checking, others might need to be loose.
+
+```js
+import { DefineObject, type } from "can/everything";
+
+class Person extends DefineObject {
+  static define = {
+    first: type.check(String),
+    last: type.maybe(String),
+
+    age: type.convert(Number),
+    birthday: type.maybeConvert(Date)
+  };
+}
+
+let fib = new Person({
+  first: "Fibonacci",
+  last: null,
+  age: "80",
+  birthday: undefined
+});
+
+console.log( fib ); // -> { ... }
+```
+@codepen
+
+When creating models with [can-rest-model] you might want to be loose in the typing of properties, especially when working with external services you do not have control over.
+
+On the other hand, when creating ViewModels for components, such as with [can-stache-define-element] you might want to be stricter about how properties are passed, to prevent mistakes.
+
+```js
+import { StacheDefineElement, type } from "can/everything";
+
+class Progress extends StacheDefineElement {
+  static define = {
+    value: {
+      type: type.check(Number),
+      default: 0
+    },
+    max: {
+      type: type.check(Number),
+      default: 100
+    },
+    get width() {
+      let w = (this.value / this.max) * 100;
+      return w + '%';
+    }
+  };
+
+  static view = `
+    <div style="background: black;">
+      <span style="background: salmon; display: inline-block; width: {{width}}">&nbsp;</span>
+    </div>
+  `;
+}
+
+customElements.define("custom-progress-bar", Progress);
+
+let progress = new Progress();
+progress.value = 34;
+
+document.body.append(progress);
+
+function increment() {
+  setTimeout(() => {
+    if(progress.value < 100) {
+      progress.value++;
+      increment();
+    }
+  }, 500);
+}
+
+increment();
+```
+@codepen
+
+See [can-stache-define-element] and [can-define-object] for more on its API.

--- a/doc/check.md
+++ b/doc/check.md
@@ -1,5 +1,5 @@
 @function can-type/check check
-@parent can-type
+@parent can-type/methods 0
 @description Create a strictly typed TypeObject.
 
 @signature `type.check(Type)`

--- a/doc/convert.md
+++ b/doc/convert.md
@@ -1,5 +1,5 @@
 @function can-type/convert convert
-@parent can-type
+@parent can-type/methods 2
 @description Create a coercing [can-type.typeobject].
 
 @signature `type.convert(Type)`

--- a/doc/maybe.md
+++ b/doc/maybe.md
@@ -1,5 +1,5 @@
 @function can-type/maybe maybe
-@parent can-type
+@parent can-type/methods 1
 @description Create a strictly typed TypeObject that also accepts `null` and `undefined` values.
 
 @signature `type.maybe(Type)`

--- a/doc/maybeConvert.md
+++ b/doc/maybeConvert.md
@@ -1,5 +1,5 @@
 @function can-type/maybeConvert maybeConvert
-@parent can-type
+@parent can-type/methods 3
 @description Create a converting [can-type.typeobject] that also accepts `null` and `undefined`.
 
 @signature `type.maybe(Type)`

--- a/doc/typeobject.md
+++ b/doc/typeobject.md
@@ -1,5 +1,5 @@
 @typedef {{}} can-type.typeobject TypeObject
-@parent can-type
+@parent can-type/types
 @description An object describing how to test membership for and convert to a specified type.
 
 @option {function(value)} can.new A function that returns an instance of a type using the provided `value`.


### PR DESCRIPTION
This improves the documentation, does a few things:

1. Uses outline 2 to show the type signatures in the main can-type docs.
2. Adds a section explaining use with can-define-object/stach-element.
3. Creates methods and types groupings for the sidebar.