### PR TITLE
not wrapping value in quotation marks if it is not a string

### DIFF
--- a/can-type.js
+++ b/can-type.js
@@ -85,7 +85,7 @@ var createNoMaybe = makeTypeFactory(function createNoMaybe(Type, action, isMembe
 });
 
 function check(Type, val) {
-	throw new Error(`Type value '${val}' is not of type ${canReflect.getName(Type)}.`);
+	throw new Error(`Type value ${typeof val === "string" ? '"' + val + '"' : val} is not of type ${canReflect.getName(Type)}.`);
 }
 
 function convert(Type, val) {


### PR DESCRIPTION
Closes https://github.com/canjs/can-type/issues/14.