### PR TITLE
added string "false" conversion and special case getSchema for Boolean

### DIFF
--- a/can-type-test.js
+++ b/can-type-test.js
@@ -34,6 +34,14 @@ var checkDateMatchesNumber = {
 	}
 };
 
+var checkBoolean = function (comparison) {
+	return {
+		check: function (assert, result) {
+			assert.strictEqual(result, comparison, "Boolea has correct conversion");
+		}
+	};
+};
+
 var matrix = {
 	check: {
 		check: strictEqual,
@@ -56,6 +64,18 @@ var dateAsNumber = new Date(1815, 11, 10).getTime();
 var testCases = [
 	{ Type: Boolean, value: true },
 	{ Type: Boolean, value: false },
+	{
+		Type: Boolean, value: 'true',
+		maybeConvert: checkBoolean(true),
+		convert: checkBoolean(true),
+	},
+	{
+		Type: Boolean, value: 'false',
+		maybeConvert: checkBoolean(false),
+		convert: checkBoolean(false),
+		maybe: checkBoolean(false),
+		check: checkBoolean(false)
+	},
 	{ Type: Number, value: 23 },
 	{ Type: String, value: "foo" },
 	{

--- a/can-type-test.js
+++ b/can-type-test.js
@@ -37,7 +37,7 @@ var checkDateMatchesNumber = {
 var checkBoolean = function (comparison) {
 	return {
 		check: function (assert, result) {
-			assert.strictEqual(result, comparison, "Boolea has correct conversion");
+			assert.strictEqual(result, comparison, "Boolean has been correctly converted");
 		}
 	};
 };


### PR DESCRIPTION
This fixes issues with filtering by Boolean with `QueryLogic` which depends on `getSchema`. The response for `getSchema` for `Boolean` was the `Boolean` constructor but needed to have both `true` and `false` as values.

Closes https://github.com/canjs/can-type/issues/16