### PR TITLE
Fix the documentation tags

### DIFF
--- a/doc/can-type.md
+++ b/doc/can-type.md
@@ -1,8 +1,9 @@
-@page can-type
+@module {Object} can-type
 @parent can-data-validation
 @collection can-ecosystem
 @group can-type/methods 0 methods
 @group can-type/types 1 types
+@package ../package.json
 @outline 2
 
 @body


### PR DESCRIPTION
- Use `@module` instead of `@page`
- Add `@package` so the GitHub and npm buttons appear in the docs