### PR TITLE
Adds type.late and friends

### DIFF
--- a/can-type-test.js
+++ b/can-type-test.js
@@ -1,3 +1,4 @@
+var canSymbol = require("can-symbol");
 var canReflect = require("can-reflect");
 var type = require("../can-type");
 var QUnit = require("steal-qunit");
@@ -127,7 +128,14 @@ testCases.forEach(function(testCase) {
 });
 
 
-QUnit.test("types.Any works as an identity", function(assert) {
+QUnit.test("type.Any works as an identity", function(assert) {
 	var result = canReflect.convert(45, type.Any);
 	assert.equal(result, 45, "Acts as a identity");
+});
+
+QUnit.test("type.late(fn) takes a function to define the type later", function(assert) {
+	var theType = type.late(() => type.convert(Number));
+	var realType = theType[canSymbol.for("can.unwrapType")]();
+	var result = canReflect.convert("45", realType);
+	assert.equal(result, 45, "Defined late but then converted");
 });

--- a/can-type.js
+++ b/can-type.js
@@ -110,6 +110,15 @@ function convert(Type, val) {
 	return canReflect.convert(val, Type);
 }
 
+function late(fn) {
+	var type = {};
+	return canReflect.assignSymbols(type, {
+		"can.unwrapType": function() {
+			return fn();
+		}
+	});
+}
+
 var Any = canReflect.assignSymbols({}, {
 	"can.new": function(val) { return val; },
 	"can.isMember": function() { return true; }
@@ -122,3 +131,4 @@ exports.convert = createNoMaybe(convert);
 exports.maybeConvert = createMaybe(convert);
 
 exports.Any = Any;
+exports.late = late;

--- a/doc/isTypeObject.md
+++ b/doc/isTypeObject.md
@@ -1,0 +1,29 @@
+@function can-type/isTypeObject isTypeObject
+@parent can-type/methods 5
+@description Determines if an object is a [can-type.typeobject].
+@signature `type.isTypeObject(Type)`
+
+  Given a Type, determines if it fits the [can-type.typeobject] protocol. To be a TypeObject, a Type needs to be an object which contains the following symbols:
+
+  * `Symbol.for("can.new")`
+  * `Symbol.for("can.isMember")`
+
+  ```js
+  import { ObservableObject, type } from "can/everything";
+
+  class Faves extends ObservableObject {}
+
+  console.log("An Typed Observable", type.isTypeObject(faves)); // true
+
+  console.log("A custom TypeObject", type.isTypeObject({
+    [Symbol.for("can.new")]() {},
+    [Symbol.for("can.isMember")]() {}
+  })); // -> true
+
+  console.log("A primitive", type.isTypeObject(null)); // -> false
+  ```
+  @codepen
+
+  @param {*} Type Anything, but usually an object of some sort.
+
+  @return {Boolean} true if it conforms to the [can-type.typeobject] protocol, otherwise false.

--- a/doc/late.md
+++ b/doc/late.md
@@ -1,0 +1,27 @@
+@function can-type/late late
+@parent can-type/methods 4
+@description Define a function that returns a type.
+@signature `type.late(fn)`
+
+  Given a function, returns a [can-type.typeobject] that will unwrap to the underlying type by calling `fn`.
+
+  ```js
+  import { ObservableObject, type } from "can/everything";
+
+  class Faves extends ObservableObject {
+    static props = {
+      faves: type.late(() => type.convert(Faves))
+    }
+  }
+
+  let faves = new Faves({
+    faves: {}
+  });
+
+  console.log("faves.faves is a Faves?", faves.faves instanceof Faves);
+  ```
+  @codepen
+
+  @param {Function} fn A function that when called returns a [can-type.typeobject].
+
+  @return {can-type.typeobject} A [can-type.typeobject] that also includes a `can.unwrapType` symbol that returns the underlying [can-type.typeobject].

--- a/doc/late.md
+++ b/doc/late.md
@@ -3,7 +3,7 @@
 @description Define a function that returns a type.
 @signature `type.late(fn)`
 
-  Given a function, returns a [can-type.typeobject] that will unwrap to the underlying type by calling `fn`.
+  Given a function, returns a [can-type.typeobject] that will unwrap to the underlying type provided within `fn`.
 
   ```js
   import { ObservableObject, type } from "can/everything";
@@ -25,3 +25,14 @@
   @param {Function} fn A function that when called returns a [can-type.typeobject].
 
   @return {can-type.typeobject} A [can-type.typeobject] that also includes a `can.unwrapType` symbol that returns the underlying [can-type.typeobject].
+
+@body
+
+# Use
+
+`type.late` provides a way to define types when a binding is not immediately available. This could be because:
+
+* You have cyclical types, such that __A__ has a property for __B__ and __B__ has a property for __A__.
+* You have a type with a property whos type is itself.
+
+In both of these cases, `type.late` provides a way to define the underlying type.

--- a/doc/normalize.md
+++ b/doc/normalize.md
@@ -1,0 +1,19 @@
+@function can-type/normalize normalize
+@parent can-type/methods 6
+@description Given any type, ensure a [can-type.typeobject] is created for it.
+@signature `type.normalize(Type)`
+
+  Given any Type, including builtin types such as `Date` and `Number`, returns a [can-type.typeobject]. For builtin constructors `type.normalize` returns a strict type for that constructor.
+
+  ```js
+  import { type } from "can/everything";
+
+  const normalizedType = type.normalize(Date);
+  const dateStrictType = type.check(Date);
+
+  // normalizedType and dateStrictType are equivalent.
+  ```
+
+  @param {Object|function} Type Anything, but usually an object of some sort.
+
+  @return {can-type.typeobject} A TypeObject representing the underlying type.

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "can-reflect": "^1.17.10"
   },
   "devDependencies": {
+    "can-symbol": "^1.6.5",
     "jshint": "^2.9.1",
     "steal": "^2.1.6",
     "steal-qunit": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,11 @@
     "types"
   ],
   "dependencies": {
-    "can-reflect": "^1.17.10"
+    "can-reflect": "^1.17.10",
+    "can-symbol": "^1.6.5"
   },
   "devDependencies": {
-    "can-symbol": "^1.6.5",
+
     "jshint": "^2.9.1",
     "steal": "^2.1.6",
     "steal-qunit": "^2.0.0",

--- a/test.html
+++ b/test.html
@@ -1,4 +1,4 @@
 <!doctype html>
-<title>can-type</title>
+<title>can-type tests</title>
 <script src="node_modules/steal/steal.js" main="~/can-type-test"></script>
 <div id="qunit-fixture"></div>


### PR DESCRIPTION
This adds 3 new functions:

* `type.late`, used to define a type "later", usually because the
binding is not immediately available.
* `type.isTypeObject`, used to determine if an object follows the
TypeObject protocol.
* `type.normalize`, given a Type, returns a TypeObject representative.
