### PR TITLE
Disallow calling new on the types created

### DIFF
--- a/can-type-test.js
+++ b/can-type-test.js
@@ -186,3 +186,13 @@ QUnit.test("type.normalize takes a Type and returns a TypeObject", function(asse
 		}
 	});
 });
+
+QUnit.test("Should not be able to call new on a TypeObject", function(assert) {
+	var typeObject = type.convert(Number);
+	try {
+		new typeObject();
+		assert.ok(false, "Should not be able to call new");
+	} catch(err) {
+		assert.ok(err, "Got an error calling new");
+	}
+});

--- a/can-type.js
+++ b/can-type.js
@@ -47,27 +47,27 @@ function makeTypeFactory(createSchema) {
 }
 
 var createMaybe = makeTypeFactory(function createMaybe(Type, action, isMember) {
-	var createNewOfType = function(val) {
-		if (val == null) {
-			return val;
-		}
-		if (val instanceof Type || isMember(val)) {
-			return val;
-		}
-		// Convert `'false'` into `false`
-		if (Type === Boolean && (val === 'false' || val === '0')) {
-			return false;
-		}
-		return action(Type, val);
-	};
+	var typeObject = {};
 
 	var values = [Type, null, undefined];
 	if (Type === Boolean) {
 		values = [true, false, null, undefined];
 	}
 
-	return canReflect.assignSymbols(createNewOfType, {
-		"can.new": createNewOfType,
+	return canReflect.assignSymbols(typeObject, {
+		"can.new": function(val) {
+			if (val == null) {
+				return val;
+			}
+			if (val instanceof Type || isMember(val)) {
+				return val;
+			}
+			// Convert `'false'` into `false`
+			if (Type === Boolean && (val === 'false' || val === '0')) {
+				return false;
+			}
+			return action(Type, val);
+		},
 		"can.getSchema": makeSchema(values),
 		"can.getName": function(){
 			return canReflect.getName(Type);
@@ -79,24 +79,24 @@ var createMaybe = makeTypeFactory(function createMaybe(Type, action, isMember) {
 });
 
 var createNoMaybe = makeTypeFactory(function createNoMaybe(Type, action, isMember) {
-	var createNewOfType = function(val) {
-		if (val instanceof Type || isMember(val)) {
-			return val;
-		}
-		// Convert `'false'` into `false`
-		if (Type === Boolean && (val === 'false' || val === '0')) {
-			return false;
-		}
-		return action(Type, val);
-	};
+	var typeObject = {};
 
 	var values = [Type];
 	if (Type === Boolean) {
 		values = [true, false];
 	}
 
-	return canReflect.assignSymbols(createNewOfType, {
-		"can.new": createNewOfType,
+	return canReflect.assignSymbols(typeObject, {
+		"can.new": function(val) {
+			if (val instanceof Type || isMember(val)) {
+				return val;
+			}
+			// Convert `'false'` into `false`
+			if (Type === Boolean && (val === 'false' || val === '0')) {
+				return false;
+			}
+			return action(Type, val);
+		},
 		"can.getSchema": makeSchema(values),
 		"can.getName": function(){
 			return canReflect.getName(Type);


### PR DESCRIPTION
By `type.check`, `type.maybe`, `type.convert`, and `type.maybeConvert`.

Closes #20