### PR TITLE
Defer to isMember symbol

### DIFF
--- a/can-type-test.js
+++ b/can-type-test.js
@@ -44,6 +44,14 @@ var checkBoolean = function (comparison) {
 	};
 };
 
+var checkNumber = function(comparison) {
+	return {
+		check: function(assert, result) {
+			assert.strictEqual(result, comparison, "Number has been correctly converted");
+		}
+	}
+};
+
 var matrix = {
 	convert: {
 		check: equal
@@ -68,6 +76,15 @@ if(process.env.NODE_ENV !== 'production') {
 }
 
 var dateAsNumber = new Date(1815, 11, 10).getTime();
+
+var Integer = {};
+Integer[canSymbol.for("can.new")] = function(val) {
+	return parseInt(val);
+};
+Integer[canSymbol.for("can.isMember")] = function(val) {
+	return Number.isInteger(val);
+};
+canReflect.setName(Integer, "Integer");
 
 var testCases = [
 	{ Type: Boolean, value: true },
@@ -100,6 +117,14 @@ var testCases = [
 		Type: Number, value: "foo",
 		convert: checkIsNaN,
 		maybeConvert: checkIsNaN
+	},
+	{
+		Type: Integer, value: 44
+	},
+	{
+		Type: Integer, value: 44.4,
+		convert: checkNumber(44),
+		maybeConvert: checkNumber(44)
 	}
 ];
 

--- a/can-type-test.js
+++ b/can-type-test.js
@@ -49,7 +49,7 @@ var checkNumber = function(comparison) {
 		check: function(assert, result) {
 			assert.strictEqual(result, comparison, "Number has been correctly converted");
 		}
-	}
+	};
 };
 
 var matrix = {

--- a/can-type.js
+++ b/can-type.js
@@ -59,7 +59,8 @@ var createMaybe = makeTypeFactory(function createMaybe(Type, action, isMember) {
 			if (val == null) {
 				return val;
 			}
-			if (val instanceof Type || isMember(val)) {
+			var isInstance = typeof Type === "function" && val instanceof Type;
+			if (isInstance || isMember(val)) {
 				return val;
 			}
 			// Convert `'false'` into `false`
@@ -73,6 +74,9 @@ var createMaybe = makeTypeFactory(function createMaybe(Type, action, isMember) {
 			return canReflect.getName(Type);
 		},
 		"can.isMember": function(value) {
+			if(Type[isMemberSymbol]) {
+				return Type[isMemberSymbol](value);
+			}
 			return value == null || value instanceof Type || isMember(value);
 		}
 	});
@@ -88,7 +92,8 @@ var createNoMaybe = makeTypeFactory(function createNoMaybe(Type, action, isMembe
 
 	return canReflect.assignSymbols(typeObject, {
 		"can.new": function(val) {
-			if (val instanceof Type || isMember(val)) {
+			var isInstance = typeof Type === "function" && val instanceof Type;
+			if (isInstance || isMember(val)) {
 				return val;
 			}
 			// Convert `'false'` into `false`
@@ -102,6 +107,9 @@ var createNoMaybe = makeTypeFactory(function createNoMaybe(Type, action, isMembe
 			return canReflect.getName(Type);
 		},
 		"can.isMember": function(value) {
+			if(Type[isMemberSymbol]) {
+				return Type[isMemberSymbol](value);
+			}
 			return value instanceof Type || isMember(value);
 		}
 	});


### PR DESCRIPTION
If a Type has an isMember symbol, defer to that rather than using
instanceof to test a type. Fixes #25