### PR TITLE
Allow types to wrap other types

### DIFF
--- a/can-type.js
+++ b/can-type.js
@@ -3,22 +3,9 @@ var canSymbol = require("can-symbol");
 
 var isMemberSymbol = canSymbol.for("can.isMember");
 var newSymbol = canSymbol.for("can.new");
+var getSchemaSymbol = canSymbol.for("can.getSchema");
 
 var type = exports;
-
-var primitives = new Map();
-canReflect.each({
-	"boolean": Boolean,
-	"number": Number,
-	"string": String
-}, function(Type, typeString) {
-	primitives.set(Type, {
-		isMember: function(val) {
-			return typeof val === typeString;
-		}
-	});
-});
-
 function makeSchema(values) {
 	return function(){
 		return {
@@ -28,103 +15,185 @@ function makeSchema(values) {
 	};
 }
 
-function makeTypeFactory(createSchema) {
-	return function makeTypeWithAction(action) {
-		var typeCache = new Map();
-
-		return function createType(Type) {
-			if(typeCache.has(Type)) {
-				return typeCache.get(Type);
-			}
-
-			var isMember = function() { return false; };
-			if(primitives.has(Type)) {
-				isMember = primitives.get(Type).isMember;
-			}
-
-			var createTypeWithSchema = createSchema(Type, action, isMember);
-			typeCache.set(Type, createTypeWithSchema);
-			return createTypeWithSchema;
-		};
+// Make an isMember function that prefers a isMemberSymbol on the Type.
+function makeIsMember(check) {
+	return function isMember(value) {
+		var Type = this.Type;
+		if(Type[isMemberSymbol]) {
+			return Type[isMemberSymbol](value);
+		}
+		if(check.call(this, value)) {
+			return true;
+		}
+		return false;
 	};
 }
 
-var createMaybe = makeTypeFactory(function createMaybe(Type, action, isMember) {
-	var typeObject = {};
+// Default isMember for non-maybe, non-primitives
+function isMember(value) {
+	return value instanceof this.Type;
+}
 
-	var values = [Type, null, undefined];
-	if (Type === Boolean) {
-		values = [true, false, null, undefined];
+// isMember for maybe non-primitives
+function maybeIsMember(value) {
+	return value == null || value instanceof this.Type;
+}
+
+// Default "can.new"
+function canNew(value) {
+	if(this.isStrict && !this[isMemberSymbol](value)) {
+		return check(this.Type, value);
 	}
 
-	return canReflect.assignSymbols(typeObject, {
-		"can.new": function(val) {
-			if (val == null) {
-				return val;
-			}
-			var isInstance = typeof Type === "function" && val instanceof Type;
-			if (isInstance || isMember(val)) {
-				return val;
-			}
-			// Convert `'false'` into `false`
-			if (Type === Boolean && (val === 'false' || val === '0')) {
-				return false;
-			}
-			return action(Type, val);
-		},
-		"can.getSchema": makeSchema(values),
-		"can.getName": function(){
-			return canReflect.getName(Type);
-		},
-		"can.isMember": function(value) {
-			if(Type[isMemberSymbol]) {
-				return Type[isMemberSymbol](value);
-			}
-			return value == null || value instanceof Type || isMember(value);
-		}
-	});
-});
+	return canReflect.convert(value, this.Type);
+}
 
-var createNoMaybe = makeTypeFactory(function createNoMaybe(Type, action, isMember) {
-	var typeObject = {};
-
-	var values = [Type];
-	if (Type === Boolean) {
-		values = [true, false];
+// "can.new" for Booleans
+function booleanNew(value) {
+	if(this.isStrict && !this[isMemberSymbol](value)) {
+		return check(Boolean, value);
 	}
+	if (value === "false" || value=== "0") {
+		return false;
+	}
+	return Boolean(value);
+}
 
-	return canReflect.assignSymbols(typeObject, {
-		"can.new": function(val) {
-			var isInstance = typeof Type === "function" && val instanceof Type;
-			if (isInstance || isMember(val)) {
-				return val;
-			}
-			// Convert `'false'` into `false`
-			if (Type === Boolean && (val === 'false' || val === '0')) {
-				return false;
-			}
-			return action(Type, val);
-		},
-		"can.getSchema": makeSchema(values),
-		"can.getName": function(){
-			return canReflect.getName(Type);
-		},
-		"can.isMember": function(value) {
-			if(Type[isMemberSymbol]) {
-				return Type[isMemberSymbol](value);
-			}
-			return value instanceof Type || isMember(value);
-		}
-	});
-});
+var maybeValues = Object.freeze([null, undefined]);
 
 function check(Type, val) {
 	throw new Error('Type value ' + typeof val === "string" ? '"' + val + '"' : val + ' is not of type ' + canReflect.getName(Type) + '.'	);
 }
 
-function convert(Type, val) {
-	return canReflect.convert(val, Type);
+/* Base converting proto */
+var baseType = {};
+canReflect.assignSymbols(baseType, {
+	isStrict: false,
+	"can.new": canNew,
+	"can.isMember": makeIsMember(isMember)
+});
+
+/* Descriptor for applying strictness */
+var strictDescriptor = {
+	isStrict: {
+		enumerable: true,
+		value: true
+	}
+};
+strictDescriptor[newSymbol] = {
+	enumerable: true,
+	value: canNew
+};
+
+/* Descriptor for applying nonstrictness */
+var unStrictDescriptor = {
+	isStrict: {
+		enumerable: true,
+		value: false
+	}
+};
+
+/* Descriptor for maybe types */
+var maybeDescriptors = {};
+maybeDescriptors[isMemberSymbol] = {
+	enumerable: false,
+	value: makeIsMember(maybeIsMember)
+};
+/* Base maybe type */
+var baseMaybeType = Object.create(baseType, maybeDescriptors);
+
+var strictMaybeDescriptor = {
+	isStrict: strictDescriptor.isStrict
+};
+strictMaybeDescriptor[isMemberSymbol] = maybeDescriptors[isMemberSymbol];
+strictMaybeDescriptor[newSymbol] = {
+	enumerable: true,
+	value: canNew
+};
+
+var unStrictMaybeDescriptor = {
+	isStrict: unStrictDescriptor.isStrict
+};
+unStrictMaybeDescriptor[isMemberSymbol] = maybeDescriptors[isMemberSymbol];
+
+var primitiveBaseTypes = new Map();
+canReflect.each({
+	"boolean": Boolean,
+	"number": Number,
+	"string": String
+}, function(Type, typeString) {
+	var noMaybeDescriptor = {};
+	var maybeDescriptor = {};
+	noMaybeDescriptor[isMemberSymbol] = {
+		enumerable: true,
+		value: 	function isMember(val) {
+			return typeof val === typeString;
+		}
+	};
+
+	maybeDescriptor[isMemberSymbol] = {
+		enumerable: true,
+		value: 	function isMaybeMember(val) {
+			return val == null || typeof val === typeString;
+		}
+	};
+
+	if(Type === Boolean) {
+		noMaybeDescriptor[newSymbol] = maybeDescriptor[newSymbol] = {
+			enumerable: true,
+			value: booleanNew
+		};
+		maybeDescriptor[getSchemaSymbol] = makeSchema([true, false, null, undefined]);
+		noMaybeDescriptor[getSchemaSymbol] = makeSchema([true, false]);
+	}
+
+	primitiveBaseTypes.set(Type, {
+		noMaybe: Object.create(baseType, noMaybeDescriptor),
+		maybe: Object.create(baseMaybeType, maybeDescriptor)
+	});
+});
+
+function addType(typeObject, Type) {
+	if(!('Type' in typeObject)) {
+		Object.defineProperty(typeObject, 'Type', {
+			value: Type
+		});
+	}
 }
+
+function getBase(Type, baseType, basePrimitiveName) {
+	if(primitiveBaseTypes.has(Type)) {
+		return primitiveBaseTypes.get(Type)[basePrimitiveName];
+	} else if(isTypeObject(Type)) {
+		return Type;
+	} else {
+		return baseType;
+	}
+}
+
+function makeTypeFactory2(name, baseType, childDescriptors, primitiveMaybe, schemaValues) {
+	var typeCache = new WeakMap();
+	return function(Type) {
+		if(typeCache.has(Type)) {
+			return typeCache.get(Type);
+		}
+
+		var base = getBase(Type, baseType, primitiveMaybe);
+		var typeObject = Object.create(base, childDescriptors);
+
+		addType(typeObject, Type);
+		typeObject[getSchemaSymbol] = makeSchema([Type].concat(schemaValues));
+		canReflect.setName(typeObject, "type." + name + "(" + canReflect.getName(Type) + ")");
+		typeCache.set(Type, typeObject);
+		return typeObject;
+	};
+}
+
+exports.check = makeTypeFactory2("check", baseType, strictDescriptor, "noMaybe", []);
+exports.convert = makeTypeFactory2("convert", baseType, unStrictDescriptor, "noMaybe", []);
+exports.maybe = makeTypeFactory2("maybe", baseMaybeType, strictMaybeDescriptor, "maybe", maybeValues);
+exports.maybeConvert = makeTypeFactory2("maybeConvert", baseMaybeType, unStrictMaybeDescriptor, "maybe", maybeValues);
+
 
 function isTypeObject(Type) {
 	if(canReflect.isPrimitive(Type)) {
@@ -166,12 +235,6 @@ var Any = canReflect.assignSymbols({}, {
 	"can.new": function(val) { return val; },
 	"can.isMember": function() { return true; }
 });
-
-exports.check = createNoMaybe(check);
-exports.maybe = createMaybe(check);
-
-exports.convert = createNoMaybe(convert);
-exports.maybeConvert = createMaybe(convert);
 
 // type checking should not throw in production
 if(process.env.NODE_ENV === 'production') {

--- a/can-type.js
+++ b/can-type.js
@@ -171,7 +171,7 @@ function getBase(Type, baseType, basePrimitiveName) {
 	}
 }
 
-function makeTypeFactory2(name, baseType, childDescriptors, primitiveMaybe, schemaValues) {
+function makeTypeFactory(name, baseType, childDescriptors, primitiveMaybe, schemaValues) {
 	var typeCache = new WeakMap();
 	return function(Type) {
 		if(typeCache.has(Type)) {
@@ -189,10 +189,10 @@ function makeTypeFactory2(name, baseType, childDescriptors, primitiveMaybe, sche
 	};
 }
 
-exports.check = makeTypeFactory2("check", baseType, strictDescriptor, "noMaybe", []);
-exports.convert = makeTypeFactory2("convert", baseType, unStrictDescriptor, "noMaybe", []);
-exports.maybe = makeTypeFactory2("maybe", baseMaybeType, strictMaybeDescriptor, "maybe", maybeValues);
-exports.maybeConvert = makeTypeFactory2("maybeConvert", baseMaybeType, unStrictMaybeDescriptor, "maybe", maybeValues);
+exports.check = makeTypeFactory("check", baseType, strictDescriptor, "noMaybe", []);
+exports.convert = makeTypeFactory("convert", baseType, unStrictDescriptor, "noMaybe", []);
+exports.maybe = makeTypeFactory("maybe", baseMaybeType, strictMaybeDescriptor, "maybe", maybeValues);
+exports.maybeConvert = makeTypeFactory("maybeConvert", baseMaybeType, unStrictMaybeDescriptor, "maybe", maybeValues);
 
 
 function isTypeObject(Type) {


### PR DESCRIPTION
This allows types to wrap other types like:

```js
type.convert(type.check(Number))
```

And flip a `isStrict` bit along the way.

This is a large refactor of how can-type works and should be more memory
efficient now, as it no longer creates a bunch of new objects in a
closure for each type and largely uses the proto chain for inheritance.

This uses the `isStrict` method to achieve flipping strictness, but
opens the door to a smaller refactor to remove this need.

This also makes it so that:

```js
type.convert(type.check(String)) === type.convert(type.check(String))
```

However, it's not currently true that:

```js
type.convert(type.maybe(String)) === type.maybeConvert(String));
```

Closes #27