### PR TITLE
Implement type.all and type.convertAll

### DIFF
--- a/can-type-test.js
+++ b/can-type-test.js
@@ -356,15 +356,35 @@ QUnit.test("Maybe types should always return a schema with an or", function(asse
 });
 
 QUnit.test("type.all converts objects", function(assert) {
+	var Person = function(values) {
+		canReflect.assignMap(this, values);
+	};
+	Person[newSymbol] = function(values) { return new Person(values); };
+	Person[getSchemaSymbol] = function() {
+		return {
+			type: "map",
+			identity: [],
+			keys: {
+				first: type.check(String),
+				last: type.check(String),
+				age: type.check(Number)
+			}
+		};
+	};
+
+	var ConvertingPerson = type.all(type.convert, Person);
+
+	var person = canReflect.new(ConvertingPerson, { first: "Wilbur", last: "Phillips", age: "8" });
+	assert.equal(typeof person.age, "number", "it is a number");
+	assert.equal(person.first, "Wilbur");
+	assert.equal(person.last, "Phillips");
+	assert.equal(person.age, 8);
+});
+
+QUnit.test("type.convertAll is a convenience for type.all(type.convert, Type)", function(assert) {
 	var Person = function() {};
 	Person[newSymbol] = function(values) {
-		var person = new Person();
-		var keys = canReflect.getSchema(this).keys;
-		canReflect.eachKey(values, function(value, key) {
-			var Type = keys[key];
-			person[key] = canReflect.convert(value, Type);
-		});
-		return person;
+		return canReflect.assignMap(new Person(), values);
 	};
 	Person[isMemberSymbol] = function(value) { return value instanceof Person };
 	Person[getSchemaSymbol] = function() {

--- a/can-type-test.js
+++ b/can-type-test.js
@@ -83,8 +83,9 @@ var Integer = {};
 Integer[canSymbol.for("can.new")] = function(val) {
 	return parseInt(val);
 };
-Integer[canSymbol.for("can.isMember")] = function(val) {
-	return Number.isInteger(val);
+Integer[canSymbol.for("can.isMember")] = function(value) {
+	// “polyfill” for Number.isInteger because it’s not supported in IE11
+	return typeof value === "number" && isFinite(value) && Math.floor(value) === value;
 };
 canReflect.setName(Integer, "Integer");
 

--- a/can-type.js
+++ b/can-type.js
@@ -230,7 +230,21 @@ function all(typeFn, Type) {
 		});
 		return schema;
 	};
-	return typeObject;
+
+	function Constructor(values) {
+		var schema = canReflect.getSchema(this);
+		var keys = schema.keys;
+		var convertedValues = {};
+		canReflect.eachKey(values || {}, function(value, key) {
+			convertedValues[key] = canReflect.convert(value, keys[key]);
+		});
+		return canReflect.new(Type, convertedValues);
+	}
+
+	canReflect.setName(Constructor, "Converted<" + canReflect.getName(Type) + ">");
+	Constructor.prototype = typeObject;
+
+	return Constructor;
 }
 
 // type checking should not throw in production

--- a/can-type.js
+++ b/can-type.js
@@ -219,6 +219,20 @@ var Any = canReflect.assignSymbols({}, {
 	"can.isMember": function() { return true; }
 });
 
+function all(typeFn, Type) {
+	var typeObject = typeFn(Type);
+	typeObject[getSchemaSymbol] = function() {
+		var parentSchema = canReflect.getSchema(Type);
+		var schema = canReflect.assignMap({}, parentSchema);
+		schema.keys = {};
+		canReflect.eachKey(parentSchema.keys, function(value, key) {
+			schema.keys[key] = typeFn(value);
+		});
+		return schema;
+	};
+	return typeObject;
+}
+
 // type checking should not throw in production
 if(process.env.NODE_ENV === 'production') {
 	exports.check = exports.convert;
@@ -229,3 +243,4 @@ exports.Any = Any;
 exports.late = late;
 exports.isTypeObject = isTypeObject;
 exports.normalize = normalize;
+exports.all = all;

--- a/doc/all.md
+++ b/doc/all.md
@@ -1,0 +1,37 @@
+@function can-type/all all
+@parent can-type/methods 7
+@description Derive a new type that changes the types of properties using a converter function.
+
+@signature `type.all(converter, Type)`
+
+  Given a converter function, which should be one of [can-type/check], [can-type/maybe], [can-type/convert], or [can-type/maybeConvert], create a new type that inherits the same properties of `Type`, but runs the converter function on them and returns a [can-type.typeobject].
+
+  ```js
+  import { ObservableObject, Reflect, type } from "can/everything";
+
+  class Person extends ObservableObject {
+    static props = {
+      age: Number
+    }
+  }
+
+  // Age is a strict number.
+
+  let person = new Person();
+  try {
+      person.age = "13";
+  } catch(err) {
+    console.log("Oops, tried to convert a strict type.");
+  }
+
+  let ConvertingPerson = type.all(type.convert, Person);
+  person = Reflect.new(Person);
+  person.age = "13";
+  console.log("Age is", person.age); // logs 13
+  ```
+  @codepen
+
+  @param {can-type/check|can-type/maybe|can-type/convert|can-type/maybeConvert} converter One of [can-type/check], [can-type/maybe], [can-type/convert], or [can-type/maybeConvert].
+  @param {Function} Type Any type with a [can-reflect.getSchema] implementation.
+
+  @return {can-type.typeobject} A [can-type.typeobject] which derives properties from the input Type.

--- a/doc/can-type.md
+++ b/doc/can-type.md
@@ -10,7 +10,7 @@
 
 ## Overview
 
-Use can-type to define rules around types to handle type checking and type conversion. Works well with [can-define], [can-define-object], and [can-stache-define-element].
+Use can-type to define rules around types to handle type checking and type conversion. Works well with [can-define], [can-observable-object], and [can-stache-element].
 
 can-type specifies the following type functions:
 
@@ -19,7 +19,7 @@ can-type specifies the following type functions:
 Use [can-type/maybe] to specify a [can-type.typeobject] which will accept a value that is a member of the provided type, or is `undefined` or `null`.
 
 ```js
-import { Reflect, type } from "can/everything";
+import { Reflect, type } from "can";
 
 const NumberType = type.maybe(Number);
 
@@ -41,7 +41,7 @@ Reflect.convert("hello world", NumberType); // throws!
 Use [can-type/convert] to define a [can-type.typeobject] which will *coerce* the value to the provided type.
 
 ```js
-import { Reflect, type } from "can/everything";
+import { Reflect, type } from "can";
 
 const NumberType = type.convert(Number);
 
@@ -55,7 +55,7 @@ console.log(val); // -> 42
 Use [can-type/maybeConvert] to define a [can-type.typeobject] which will *coerce* the value to the type, but also accept values of `null` and `undefined`.
 
 ```js
-import { Reflect, type } from "can/everything";
+import { Reflect, type } from "can";
 
 const DateType = type.maybeConvert(Date);
 
@@ -80,7 +80,7 @@ console.log(val); // -> Date{12/04/1433}
 Use [can-type/check] to specify a strongly typed [can-type.typeobject] that verifies the value passed is of the same type.
 
 ```js
-import { Reflect, type } from "can/everything";
+import { Reflect, type } from "can";
 
 const StringType = type.check(String);
 
@@ -93,10 +93,10 @@ Reflect.convert(42, StringType); // throws!
 
 ## Creating Models and ViewModels
 
-can-type is useful for creating typed properties in [can-define-object]. You might want to use stricter type checking for some properties or classes and looser type checking for others. The following creates properties with various properties and type methods:
+can-type is useful for creating typed properties in [can-observable-object]. You might want to use stricter type checking for some properties or classes and looser type checking for others. The following creates properties with various properties and type methods:
 
 ```js
-import { DefineObject, type } from "can/everything";
+import { ObservableObject, type } from "can";
 
 class Person extends DefineObject {
   static define = {
@@ -119,14 +119,14 @@ console.log(fib); // ->Person{ ... }
 ```
 @codepen
 
-> Note: as mentioned in the comment above, type checking is the default behavior of [can-define-object], so `first: type.check(String)` could be written as `first: String`.
+> Note: as mentioned in the comment above, type checking is the default behavior of [can-observable-object], so `first: type.check(String)` could be written as `first: String`.
 
 When creating models with [can-rest-model] you might want to be loose in the typing of properties, especially when working with external services you do not have control over.
 
-On the other hand, when creating ViewModels for components, such as with [can-stache-define-element] you might want to be stricter about how properties are passed, to prevent mistakes.
+On the other hand, when creating ViewModels for components, such as with [can-stache-element] you might want to be stricter about how properties are passed, to prevent mistakes.
 
 ```js
-import { StacheDefineElement, type } from "can/everything";
+import { StacheElement, type } from "can";
 
 class Progress extends StacheDefineElement {
   static define = {
@@ -173,7 +173,7 @@ increment();
 
 > Note: Having both `type: type.check(Number)` and `default: 0` in the same definition is redundant. Using `default: 0` will automatically set up type checking. It is shown above for clarity.
 
-See [can-stache-define-element] and [can-define-object] for more on these APIs.
+See [can-stache-element] and [can-observable-object] for more on these APIs.
 
 ## How it works
 

--- a/doc/can-type.md
+++ b/doc/can-type.md
@@ -98,7 +98,7 @@ can-type is useful for creating typed properties in [can-observable-object]. You
 ```js
 import { ObservableObject, type } from "can";
 
-class Person extends DefineObject {
+class Person extends ObservableObject {
   static define = {
     first: type.check(String), // type checking is the default behavior
     last: type.maybe(String),
@@ -128,7 +128,7 @@ On the other hand, when creating ViewModels for components, such as with [can-st
 ```js
 import { StacheElement, type } from "can";
 
-class Progress extends StacheDefineElement {
+class Progress extends StacheElement {
   static define = {
     value: {
       type: type.check(Number),

--- a/doc/can-type.md
+++ b/doc/can-type.md
@@ -1,6 +1,6 @@
 @module {Object} can-type
 @parent can-data-validation
-@collection can-ecosystem
+@collection can-core
 @group can-type/methods 0 methods
 @group can-type/types 1 types
 @package ../package.json

--- a/doc/can-type.md
+++ b/doc/can-type.md
@@ -1,8 +1,9 @@
-@page can-type
+@module {Object} can-type
 @parent can-data-validation
 @collection can-ecosystem
 @group can-type/methods 0 methods
 @group can-type/types 1 types
+@package ../package.json
 @outline 2
 
 @body

--- a/doc/convertAll.md
+++ b/doc/convertAll.md
@@ -1,0 +1,58 @@
+@function can-type/convertAll convertAll
+@parent can-type/methods 8
+@description Derive a new type that makes every property of Type convert, eliminating strict type checking.
+
+@signature `type.convertAll(Type)`
+
+  Given a `Type`, creates a [can-type.typeobject] where each property on the Type is converted, rather than being strictly checked.
+
+  ```js
+  import { ObservableObject, Reflect, type } from "can/everything";
+
+  class Person extends ObservableObject {
+    static props = {
+      age: Number
+    }
+  }
+
+  // Age is a strict number.
+
+  let person = new Person();
+  try {
+      person.age = "13";
+  } catch(err) {
+    console.log("Oops, tried to convert a strict type.");
+  }
+
+  let ConvertingPerson = type.convertAll(Person);
+  person = Reflect.new(Person);
+  person.age = "13";
+  console.log("Age is", person.age); // logs 13
+  ```
+  @codepen
+
+  @param {Function} Type Any type with a [can-reflect.getSchema] implementation.
+
+  @return {can-type.typeobject} A [can-type.typeobject] which derives properties from the input Type.
+
+@body
+
+## Use with fixture.store
+
+This function is useful to create derived types where any strict types are ignored. Useful in cases where you might receive strings for each key.
+
+One example is using [can-fixture.store], which will provide string values in some cases. `type.convertAll` can be used to create a type where this works.
+
+```js
+import { fixture, ObservableObject, type } from "can/everything";
+
+class Person extends ObservableObject {
+  static props = {
+    age: Number
+  };
+}
+
+const items = [{ id: 1, age: "13"}];
+
+fixture.store(items, type.convertAll(Person));
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "0.1.10",
+  "version": "0.1.11",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "0.1.13",
+  "version": "1.0.0-pre.0",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "1.0.0-pre.0",
+  "version": "1.0.0-pre.1",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-    "release:pre": "npm version preversion && npm publish"
+    "release:pre": "npm version prerelease && npm publish"
   },
   "main": "can-type.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "1.0.0-pre.6",
+  "version": "1.0.0-pre.7",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "1.0.0-pre.1",
+  "version": "1.0.0-pre.2",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "1.0.0-pre.5",
+  "version": "1.0.0-pre.6",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "jshint": "jshint ./*.js --config",
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish"
+    "release:major": "npm version major && npm publish",
+    "release:pre": "npm version preversion && npm publish"
   },
   "main": "can-type.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "1.0.0-pre.2",
+  "version": "1.0.0-pre.3",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "1.0.0-pre.3",
+  "version": "1.0.0-pre.4",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "1.0.0-pre.4",
+  "version": "1.0.0-pre.5",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "can-type",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Type definitions",
   "homepage": "https://canjs.com/doc/can-type.html",
   "repository": {


### PR DESCRIPTION
This adds implementations of `type.all` and `type.convertAll` as described in #31. This closes #31 

Example usage:

```js
import { ObservableObject, type } from "can";

class Person extends ObservableObject {
  static props = {
    age: Number
  };
}

let person = new Person({ age: "13" }); // throws

const ConvertingPerson = type.convertAll(Person);

person = new ConvertingPerson({ age: "13" });
console.log(person.age); // 13
```

Docs are included.