### PR TITLE
Implementations of type.all and type.convertAll

### DIFF
--- a/can-type-test.js
+++ b/can-type-test.js
@@ -356,15 +356,35 @@ QUnit.test("Maybe types should always return a schema with an or", function(asse
 });
 
 QUnit.test("type.all converts objects", function(assert) {
+	var Person = function(values) {
+		canReflect.assignMap(this, values);
+	};
+	Person[newSymbol] = function(values) { return new Person(values); };
+	Person[getSchemaSymbol] = function() {
+		return {
+			type: "map",
+			identity: [],
+			keys: {
+				first: type.check(String),
+				last: type.check(String),
+				age: type.check(Number)
+			}
+		};
+	};
+
+	var ConvertingPerson = type.all(type.convert, Person);
+
+	var person = canReflect.new(ConvertingPerson, { first: "Wilbur", last: "Phillips", age: "8" });
+	assert.equal(typeof person.age, "number", "it is a number");
+	assert.equal(person.first, "Wilbur");
+	assert.equal(person.last, "Phillips");
+	assert.equal(person.age, 8);
+});
+
+QUnit.test("type.convertAll is a convenience for type.all(type.convert, Type)", function(assert) {
 	var Person = function() {};
 	Person[newSymbol] = function(values) {
-		var person = new Person();
-		var keys = canReflect.getSchema(this).keys;
-		canReflect.eachKey(values, function(value, key) {
-			var Type = keys[key];
-			person[key] = canReflect.convert(value, Type);
-		});
-		return person;
+		return canReflect.assignMap(new Person(), values);
 	};
 	Person[isMemberSymbol] = function(value) { return value instanceof Person };
 	Person[getSchemaSymbol] = function() {

--- a/can-type-test.js
+++ b/can-type-test.js
@@ -386,7 +386,7 @@ QUnit.test("type.convertAll is a convenience for type.all(type.convert, Type)", 
 	Person[newSymbol] = function(values) {
 		return canReflect.assignMap(new Person(), values);
 	};
-	Person[isMemberSymbol] = function(value) { return value instanceof Person };
+	Person[isMemberSymbol] = function(value) { return value instanceof Person; };
 	Person[getSchemaSymbol] = function() {
 		return {
 			type: "map",
@@ -399,7 +399,7 @@ QUnit.test("type.convertAll is a convenience for type.all(type.convert, Type)", 
 		};
 	};
 
-	var ConvertingPerson = type.all(type.convert, Person);
+	var ConvertingPerson = type.convertAll(Person);
 
 	var person = canReflect.new(ConvertingPerson, { first: "Wilbur", last: "Phillips", age: "8" });
 	assert.equal(typeof person.age, "number", "it is a number");

--- a/can-type.js
+++ b/can-type.js
@@ -230,7 +230,21 @@ function all(typeFn, Type) {
 		});
 		return schema;
 	};
-	return typeObject;
+
+	function Constructor(values) {
+		var schema = canReflect.getSchema(this);
+		var keys = schema.keys;
+		var convertedValues = {};
+		canReflect.eachKey(values || {}, function(value, key) {
+			convertedValues[key] = canReflect.convert(value, keys[key]);
+		});
+		return canReflect.new(Type, convertedValues);
+	}
+
+	canReflect.setName(Constructor, "Converted<" + canReflect.getName(Type) + ">");
+	Constructor.prototype = typeObject;
+
+	return Constructor;
 }
 
 // type checking should not throw in production

--- a/can-type.js
+++ b/can-type.js
@@ -219,6 +219,20 @@ var Any = canReflect.assignSymbols({}, {
 	"can.isMember": function() { return true; }
 });
 
+function all(typeFn, Type) {
+	var typeObject = typeFn(Type);
+	typeObject[getSchemaSymbol] = function() {
+		var parentSchema = canReflect.getSchema(Type);
+		var schema = canReflect.assignMap({}, parentSchema);
+		schema.keys = {};
+		canReflect.eachKey(parentSchema.keys, function(value, key) {
+			schema.keys[key] = typeFn(value);
+		});
+		return schema;
+	};
+	return typeObject;
+}
+
 // type checking should not throw in production
 if(process.env.NODE_ENV === 'production') {
 	exports.check = exports.convert;
@@ -229,3 +243,4 @@ exports.Any = Any;
 exports.late = late;
 exports.isTypeObject = isTypeObject;
 exports.normalize = normalize;
+exports.all = all;

--- a/can-type.js
+++ b/can-type.js
@@ -258,3 +258,4 @@ exports.late = late;
 exports.isTypeObject = isTypeObject;
 exports.normalize = normalize;
 exports.all = all;
+exports.convertAll = all.bind(null, exports.convert);

--- a/doc/all.md
+++ b/doc/all.md
@@ -4,7 +4,7 @@
 
 @signature `type.all(converter, Type)`
 
-  Given a converter function, which should be one of [can-type/check], [can-type/maybe], [can-type/convert], or [can-type/maybeConvert], create a new type that inherits the same properties of `Type`, but runs the converter function on them and returns a [can-type.typeobject].
+  Create a new type that inherits the same properties of `Type`, but with each property run through the converter function. The converter function should be one of [can-type/check], [can-type/maybe], [can-type/convert], or [can-type/maybeConvert].
 
   ```js
   import { ObservableObject, Reflect, type } from "can/everything";

--- a/doc/all.md
+++ b/doc/all.md
@@ -1,0 +1,37 @@
+@function can-type/all all
+@parent can-type/methods 7
+@description Derive a new type that changes the types of properties using a converter function.
+
+@signature `type.all(converter, Type)`
+
+  Given a converter function, which should be one of [can-type/check], [can-type/maybe], [can-type/convert], or [can-type/maybeConvert], create a new type that inherits the same properties of `Type`, but runs the converter function on them and returns a [can-type.typeobject].
+
+  ```js
+  import { ObservableObject, Reflect, type } from "can/everything";
+
+  class Person extends ObservableObject {
+    static props = {
+      age: Number
+    }
+  }
+
+  // Age is a strict number.
+
+  let person = new Person();
+  try {
+      person.age = "13";
+  } catch(err) {
+    console.log("Oops, tried to convert a strict type.");
+  }
+
+  let ConvertingPerson = type.all(type.convert, Person);
+  person = Reflect.new(Person);
+  person.age = "13";
+  console.log("Age is", person.age); // logs 13
+  ```
+  @codepen
+
+  @param {can-type/check|can-type/maybe|can-type/convert|can-type/maybeConvert} converter One of [can-type/check], [can-type/maybe], [can-type/convert], or [can-type/maybeConvert].
+  @param {Function} Type Any type with a [can-reflect.getSchema] implementation.
+
+  @return {can-type.typeobject} A [can-type.typeobject] which derives properties from the input Type.

--- a/doc/convertAll.md
+++ b/doc/convertAll.md
@@ -4,7 +4,7 @@
 
 @signature `type.convertAll(Type)`
 
-  Given a `Type`, creates a [can-type.typeobject] where each property on the Type is converted, rather than being strictly checked.
+  Create a new type that inherits the same properties of `Type`, but where each property on the `Type` is converted, rather than being strictly checked.
 
   ```js
   import { ObservableObject, Reflect, type } from "can/everything";

--- a/doc/convertAll.md
+++ b/doc/convertAll.md
@@ -1,0 +1,58 @@
+@function can-type/convertAll convertAll
+@parent can-type/methods 8
+@description Derive a new type that makes every property of Type convert, eliminating strict type checking.
+
+@signature `type.convertAll(Type)`
+
+  Given a `Type`, creates a [can-type.typeobject] where each property on the Type is converted, rather than being strictly checked.
+
+  ```js
+  import { ObservableObject, Reflect, type } from "can/everything";
+
+  class Person extends ObservableObject {
+    static props = {
+      age: Number
+    }
+  }
+
+  // Age is a strict number.
+
+  let person = new Person();
+  try {
+      person.age = "13";
+  } catch(err) {
+    console.log("Oops, tried to convert a strict type.");
+  }
+
+  let ConvertingPerson = type.convertAll(Person);
+  person = Reflect.new(Person);
+  person.age = "13";
+  console.log("Age is", person.age); // logs 13
+  ```
+  @codepen
+
+  @param {Function} Type Any type with a [can-reflect.getSchema] implementation.
+
+  @return {can-type.typeobject} A [can-type.typeobject] which derives properties from the input Type.
+
+@body
+
+## Use with fixture.store
+
+This function is useful to create derived types where any strict types are ignored. Useful in cases where you might receive strings for each key.
+
+One example is using [can-fixture.store], which will provide string values in some cases. `type.convertAll` can be used to create a type where this works.
+
+```js
+import { fixture, ObservableObject, type } from "can/everything";
+
+class Person extends ObservableObject {
+  static props = {
+    age: Number
+  };
+}
+
+const items = [{ id: 1, age: "13"}];
+
+fixture.store(items, type.convertAll(Person));
+```


### PR DESCRIPTION
This adds implementations of `type.all` and `type.convertAll` as described in #31. This closes #31 

Example usage:

```js
import { ObservableObject, type } from "can";

class Person extends ObservableObject {
  static props = {
    age: Number
  };
}

let person = new Person({ age: "13" }); // throws

const ConvertingPerson = type.convertAll(Person);

person = new ConvertingPerson({ age: "13" });
console.log(person.age); // 13
```

Docs are included.