### PR TITLE
Improvements to the docs

### DIFF
--- a/doc/all.md
+++ b/doc/all.md
@@ -7,7 +7,7 @@
   Create a new type that inherits the same properties of `Type`, but with each property run through the converter function. The converter function should be one of [can-type/check], [can-type/maybe], [can-type/convert], or [can-type/maybeConvert].
 
   ```js
-  import { ObservableObject, Reflect, type } from "can/everything";
+  import { ObservableObject, Reflect, type } from "can";
 
   class Person extends ObservableObject {
     static props = {

--- a/doc/any.md
+++ b/doc/any.md
@@ -7,30 +7,46 @@
   Like an [identity function](https://en.wikipedia.org/wiki/Identity_function), `type.Any` is a [can-type.typeobject] that allows any type of a value to be allowed without checking or coercion.
 
   ```js
-  import { Reflect, type } from "can/everything";
+  import { ObservableObject, type } from "can";
 
-  let val = Reflect.convert(42, type.Any);
-  console.log(val); // -> 42
+  class EnvironmentVariable extends ObservableObject {
+    static props = {
+      value: type.Any
+    };
+  }
 
-  val = Reflect.convert(null, type.Any);
-  console.log(val); // -> null
+  let env = new EnvironmentVariable();
+  env.value = 42;
+  console.log(env.value); // -> 42
 
-  val = Reflect.convert([], type.Any);
-  console.log(val); // -> []
+  env.value = null;
+  console.log(env.value); // -> null
 
-  val = Reflect.convert(new Date(), type.Any);
-  console.log(val); // Date()
+  env.value = [];
+  console.log(env.value); // -> []
+
+  env.value = new Date();
+  console.log(env.value); // -> Date
   ```
   @codepen
 
   `type.Any` returns the same instance as passed into [can-reflect.convert] so they are referentially identical.
 
   ```js
-  import { Reflect, type } from "can/everything";
+  import { ObservableObject, type } from "can";
+
+  class Schedule extends ObservableObject {
+    static props = {
+      firstPeriod: type.Any
+    };
+  }
 
   let today = new Date();
+  let sched = new Schedule();
+  
+  sched.firstPeriod = today;
 
-  let val = Reflect.convert(today, type.Any);
-  console.log(val); // today
+  console.log(sched.firstPeriod === today); // -> true
+  console.log(sched.firstPeriod); // -> today
   ```
   @codepen

--- a/doc/check.md
+++ b/doc/check.md
@@ -6,17 +6,36 @@
 
   Given a type, returns a [can-type.typeobject] that will check values against that type. Throws if another type is provided as a value.
 
+  The following creates an object with a strongly typed [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number) so that any other value cannot be passed to it.
+
   ```js
-  import { Reflect, type } from "can/everything";
+  import { ObservableObject, type } from "can";
 
-  let val = Reflect.convert(new Date(), type.check(Date));
-  console.log(val); // Date()
+  class Pagination extends ObservableObject {
+    static props = {
+      num: type.check(Number)
+    };
+  }
 
-  Reflect.convert("12/14/1933", type.check(Date));
+  let page = new Pagination({ num: 1 });
+  console.log(page.num); // -> 1
+
+  page.num = 2;
+  console.log(page.num); // -> 2
+
+  page.num = "4";
   // throws for providing an invalid type.
   ```
   @codepen
 
-  @param {Function} Type A constructor function that values will be checked against.
+  @param {Function} Type A constructor function that values will be checked against. Often this will be the primitive constructors [String](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), [Number](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number), [Boolean](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Boolean), or [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date), but could be any class type.
 
   @return {can-type.typeobject} A [can-type.typeobject] which will strictly enforce values of the provided type.
+
+@body
+
+## Use Case
+
+Use __type.check__ to create strongly typed properties. This is useful when used with [can-stache-element StacheElement] components. Strongly typed properties helps to *ensure* that the component works correctly because invalid types cannot creep in and cause unexpected behavior.
+
+Using strongly typed properties with can-type sends a singal to users of the component that the component needs these properties in a certain type.

--- a/doc/convert.md
+++ b/doc/convert.md
@@ -1,23 +1,37 @@
 @function can-type/convert convert
 @parent can-type/methods 2
-@description Create a coercing [can-type.typeobject].
+@description Create a [can-type.typeobject] that converts values to the given type.
 
 @signature `type.convert(Type)`
 
   Given a type, returns a [can-type.typeobject] that will coerce values to that type.
 
   ```js
-  import { Reflect, type } from "can/everything";
+  import { ObservableObject, type } from "can";
 
-  let date = new Date();
-  let val = Reflect.convert(date, type.convert(Date));
-  console.log(val); // date
+  class Event extends ObservableObject {
+    static props = {
+      date: type.convert(Date)
+    };
+  }
 
-  val = Reflect.convert("12/14/1933", type.convert(Date));
-  console.log(val); // Date{12/14/1933}
+  let event = new Event({
+    date: new Date()
+  });
+
+  console.log(event.date); // -> Date
+
+  event.date = "12/14/1933";
+  console.log(event.date); // -> Date{12/14/1933}
   ```
   @codepen
 
   @param {Function} Type A constructor function that values will be checked against.
 
   @return {can-type.typeobject} A [can-type.typeobject] which will *coerce* values to the provided type.
+
+@body
+
+## Use Case
+
+Use __type.convert__ to build types for models, such as those with [can-rest-model] and [can-realtime-rest-model]. You often want to use convert because the database where data is stored will serialize types. This is true of of the [Date](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date) type which is often serialized as strings. It's also true of subtypes (like other [can-observable-object ObservableObjects]) which are serialized as plain objects.

--- a/doc/convertAll.md
+++ b/doc/convertAll.md
@@ -7,7 +7,7 @@
   Create a new type that inherits the same properties of `Type`, but where each property on the `Type` is converted, rather than being strictly checked.
 
   ```js
-  import { ObservableObject, Reflect, type } from "can/everything";
+  import { ObservableObject, Reflect, type } from "can";
 
   class Person extends ObservableObject {
     static props = {
@@ -44,7 +44,7 @@ This function is useful to create derived types where any strict types are ignor
 One example is using [can-fixture.store], which will provide string values in some cases. `type.convertAll` can be used to create a type where this works.
 
 ```js
-import { fixture, ObservableObject, type } from "can/everything";
+import { fixture, ObservableObject, type } from "can";
 
 class Person extends ObservableObject {
   static props = {

--- a/doc/isTypeObject.md
+++ b/doc/isTypeObject.md
@@ -9,7 +9,7 @@
   * `Symbol.for("can.isMember")`
 
   ```js
-  import { ObservableObject, type } from "can/everything";
+  import { ObservableObject, type } from "can";
 
   class Faves extends ObservableObject {}
 

--- a/doc/late.md
+++ b/doc/late.md
@@ -6,7 +6,7 @@
   Given a function, returns a [can-type.typeobject] that will unwrap to the underlying type provided within `fn`.
 
   ```js
-  import { ObservableObject, type } from "can/everything";
+  import { ObservableObject, type } from "can";
 
   class Faves extends ObservableObject {
     static props = {

--- a/doc/maybe.md
+++ b/doc/maybe.md
@@ -7,22 +7,67 @@
   Given a type, returns a [can-type.typeobject] that will check values against against that type. Throws if the value is not of the provided type or `null` or `undefined`.
 
   ```js
-  import { Reflect, type } from "can/everything";
+  import { ObservableObject, type } from "can";
 
-  let val = Reflect.convert(42, type.maybe(Number));
-  console.log(val); // -> 42
+  class Person extends ObservableObject {
+    static props = {
+      first: type.check(String),
+      last: type.maybe(String)
+    };
+  }
 
-  val = Reflect.convert(null, type.maybe(Number));
-  console.log(val); // -> null
+  let person = new Person({
+    first: "Matthew",
+    last: null
+  });
 
-  val = Reflect.convert(undefined, type.maybe(Number));
-  console.log(val); // -> undefined
-
-  Reflect.convert("42", type.maybe(Number));
-  // throws for providing an invalid type.
+  console.log(person.first, person.last); // "Matthew" null
   ```
   @codepen
 
   @param {Function} Type A constructor function that values will be checked against.
 
   @return {can-type.typeobject} A [can-type.typeobject] which will enforce conversion to the given type.
+
+@body
+
+# Use Case
+
+Using __type.maybe__ you can create types that accept a type, null, or undefined. This is useful in cases where a type is *optional* but it is more convenient to pass a value even when one doesn't exist.
+
+An example is when binding to a child component (such as a [can-stache-element StacheElement]). Using bindings means you'll always pass *something* to that child component, you can't pass nothing. Without a good default value you might want to pass undefined.
+
+```js
+import { StacheElement, type } from "can";
+
+class Child extends StacheElement {
+  static view = `
+    {{# if(this.name) }}
+      {{name}}
+    {{ else }}
+      No name given!
+    {{/ if }}
+  `;
+
+  static props = {
+    name: type.maybe(String)
+  };
+}
+
+customElements.define("child-el", Child);
+
+class Parent extends StacheElement {
+  static view = `
+    <child-el name:from="this.name" />
+  `;
+
+  static props = {
+    name: type.maybe(String)
+  };
+}
+
+customElements.define("parent-el", Parent);
+let el = new Parent();
+document.body.append(el);
+```
+@codepen

--- a/doc/maybeConvert.md
+++ b/doc/maybeConvert.md
@@ -7,22 +7,31 @@
   Given a type, returns a [can-type.typeobject] that will check values against that type. Coerces if the value is not of the provided type or `null` or `undefined`.
 
   ```js
-  import { Reflect, type } from "can/everything";
+  import { ObservableObject, type } from "can";
 
-  let val = Reflect.convert(42, type.maybeConvert(Number));
-  console.log(val); // -> 42
+  class Person extends ObservableObject {
+    static props = {
+      age: maybeConvert(Number)
+    };
+  }
 
-  val = Reflect.convert(null, type.maybeConvert(Number));
-  console.log(val); // -> null
+  let person = new Person();
+  person.age = 42; // -> 42
 
-  val = Reflect.convert(undefined, type.maybeConvert(Number));
-  console.log(val); // -> undefined
+  person.age = null; // -> null
 
-  val = Reflect.convert("42", type.maybeConvert(Number));
-  console.log(val); // -> 42
+  person.age = undefined; // -> undefined
+
+  person.age = "42"; // -> 42
   ```
   @codepen
 
   @param {Function} Type A constructor function that values will be checked against.
 
   @return {can-type.typeobject} A [can-type.typeobject] which will enforce conversion to the given type.
+
+@body
+
+## Use Case
+
+Like with [can-type/convert], __type.maybeConvert__ is particularly useful when building models for service layers (like with [can-rest-model] and [can-realtime-rest-model]. Some server-side data layers will transfer empty values in database as either `null` or `undefined`. Using type.maybeConvert will prevent these values from throwing, but also attempt to convert them when a value does exist.

--- a/doc/normalize.md
+++ b/doc/normalize.md
@@ -6,7 +6,7 @@
   Given any Type, including builtin types such as `Date` and `Number`, returns a [can-type.typeobject]. For builtin constructors `type.normalize` returns a strict type for that constructor.
 
   ```js
-  import { type } from "can/everything";
+  import { type } from "can";
 
   const normalizedType = type.normalize(Date);
   const dateStrictType = type.check(Date);

--- a/doc/typeobject.md
+++ b/doc/typeobject.md
@@ -11,7 +11,7 @@
 A `TypeObject` is any object which conforms to this API:
 
 ```js
-import { Reflect } from "can/everything";
+import { Reflect } from "can";
 
 const dateType = {
   [Symbol.for("can.new")](value) {


### PR DESCRIPTION
This improves documentation based on feedback from a user-test. The main
can-type docs are now more use-case centric and give you where each of
the type functions is most likely used for. Additionally most examples
have switched from being can-reflect based to now showing
ObservableObjects or StacheElements since that is the place where most
users will use can-type.