### PR TITLE
Update can-type.js

### DIFF
--- a/can-type.js
+++ b/can-type.js
@@ -272,12 +272,13 @@ exports.maybeConvert = makeCache(function(Type) {
 	return o;
 });
 
+//!steal-remove-start
 // type checking should not throw in production
 if(process.env.NODE_ENV === 'production') {
 	exports.check = exports.convert;
 	exports.maybe = exports.maybeConvert;
 }
-
+//!steal-remove-end
 exports.Any = Any;
 exports.Integer = Integer;
 


### PR DESCRIPTION
Added Steal remove so that this is useable in the browser without throwing errors when it gets bundled and steal comments striped out

Closes: #50 