### PR TITLE
Fix maybeConvert usage error

### DIFF
--- a/doc/maybeConvert.md
+++ b/doc/maybeConvert.md
@@ -11,7 +11,7 @@
 
   class Person extends ObservableObject {
     static props = {
-      age: maybeConvert(Number)
+      age: type.maybeConvert(Number)
     };
   }
 


### PR DESCRIPTION
maybeConvert in the first example should be used with `type.maybeConvert` to avoid error when running example on CodePen.